### PR TITLE
Fixed bug in key reset on dataXORdWithData selector.

### DIFF
--- a/SQRLAuthentication/Categories/NSData+XOR.m
+++ b/SQRLAuthentication/Categories/NSData+XOR.m
@@ -36,7 +36,7 @@
 
         // If at end of key data, reset count and
         // set key pointer back to start of key value
-        if (++keyIndex == self.length)
+        if (++keyIndex == data.length)
 		{
             keyIndex = 0;
 			keyPtr = keyData;


### PR DESCRIPTION
The logic of the changed IF is to handle cases where the data that is being XOR'd (key/data) into the input (self) is of a smaller length. If the length of the key is reached, we reset the pointer to the beginning of the key - repeating the key.

Sample inputs for testing:

Plain Text:
an old man stays at home
3test123

Base 64:
YW4gb2xkIG1hbiBzdGF5cyBhdCBob21l
M3Rlc3QxMjM=

XOR result:
UhpFHBhVEl5SGkUAAFBLQBMVEVMcXl9W

The equivalent is XORing an "old man stays at home" with "3test1233test1233test123"
